### PR TITLE
Implement the G Suite group listing via user impersonation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+# .travis.yml
+language: go
+go:
+  - '1.10.2'
+
+before_install:
+  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+install:
+  - dep ensure -v
+
+script:
+  - go build
+  - rm vault-auth-google
+
+after_success:
+  - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:62750fcd190d5c1a50ed49fcbfa70ef83d7481a4d5570de677a82411091c4bf5"
+  digest = "1:2b10b9a545074605403d32baf9dda24b7582976ba7e9b46c4c7b9da9edac03e7"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = ""
-  revision = "29f476ffa9c4cd4fd14336b6043090ac1ad76733"
-  version = "v0.21.0"
+  revision = "aad3f485ee528456e0768f20397b4d9dd941e755"
+  version = "v0.25.0"
 
 [[projects]]
   digest = "1:8855efc2aff3afd6319da41b22a8ca1cfd1698af05a24852c01636ba65b133f0"
@@ -39,7 +39,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:bcb38c8fc9b21bb8682ce2d605a7d4aeb618abc7f827e3ac0b27c0371fdb23fb"
+  digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -49,24 +49,24 @@
     "ptypes/timestamp",
   ]
   pruneopts = ""
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:09307dfb1aa3f49a2bf869dcfa4c6c06ecd3c207221bd1c1a1141f0e51f209eb"
+  digest = "1:2a5888946cdbc8aa360fd43301f9fc7869d663f60d5eedae7d4e6e5e4f06f2bf"
   name = "github.com/golang/snappy"
   packages = ["."]
   pruneopts = ""
-  revision = "553a641470496b2327abcac10b36396bd98e45c9"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
   branch = "master"
-  digest = "1:304c322b62533a48ac052ffee80f67087fce1bc07186cd4e610a1b0e77765836"
+  digest = "1:4fe55793760295fbef367890352b720784243e0ad19b5ee242519a4682bb9ef8"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
   pruneopts = ""
-  revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
+  revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
 
 [[projects]]
   branch = "master"
@@ -78,19 +78,27 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fc9a2736d92cf885c9b3c7f202d3aaf783bb2cc4124078f0ef7667b72173b66c"
+  digest = "1:d8d774b09991b54cb044144e750e0f4dafe082ef217dfee5e57f2075f31e3272"
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
   pruneopts = ""
-  revision = "69ff559dc25f3b435631604f573a5fa1efdb6433"
+  revision = "ff2cf002a8dd750586d91dddd4470c341f981fe1"
 
 [[projects]]
   branch = "master"
-  digest = "1:b46ef59de1f724e8a2b508ea2b329eaf6cac4d71cbd44ad5e3dbd4e8fd49de9b"
+  digest = "1:4423ee95d6ee30bb22f680445c58889bb5b91e1b955405bf34374a053784a8a2"
+  name = "github.com/hashicorp/go-immutable-radix"
+  packages = ["."]
+  pruneopts = ""
+  revision = "7f3cd4390caab3250a57f30efdb2a65dd7649ecf"
+
+[[projects]]
+  branch = "master"
+  digest = "1:0b5ca7d18e4ded1e4dacbb37ff027cb40a80c0fed969e4e03cf7aff129bc1b44"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   pruneopts = ""
-  revision = "b7773ae218740a7be65057fc60b366a49b538a44"
+  revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
 
 [[projects]]
   branch = "master"
@@ -102,11 +110,27 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:16503ad296459b0e65fbe60a5f41c097bd325c3f981fd26a5397bb0edbe3e31c"
+  name = "github.com/hashicorp/go-retryablehttp"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+
+[[projects]]
+  branch = "master"
   digest = "1:ff65bf6fc4d1116f94ac305342725c21b55c16819c2606adc8f527755716937f"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
   pruneopts = ""
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
+
+[[projects]]
+  branch = "master"
+  digest = "1:fd8ec2359315965bb6b84fd8e45cd5e8b58b80d8430dc96c8c5dfce46d30dbfc"
+  name = "github.com/hashicorp/go-sockaddr"
+  packages = ["."]
+  pruneopts = ""
+  revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
 
 [[projects]]
   branch = "master"
@@ -118,11 +142,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:94158926759c3333201f81eee5a21112f7ae9d000b4d6926455008c7ab3fb7fc"
+  digest = "1:139bdc2c89779b8ff8b1150be28f889b0ed964e6da96f32cbc9035bd4642881c"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
   pruneopts = ""
-  revision = "23480c0665776210b5fbbac6eaaee40e3e6a96b7"
+  revision = "270f2f71b1ee587f3b609f00f422b76a6b28f348"
 
 [[projects]]
   branch = "master"
@@ -154,7 +178,7 @@
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
-  digest = "1:820c02b39c079c8919901ea9cc75b93ae8bc0864271494f40f7eb78fd69a8cbb"
+  digest = "1:d18bd2106eed6a53efcd3f4dc9faa9492488f51b94e6fd80eae92abda0ec0202"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
@@ -162,11 +186,13 @@
     "helper/compressutil",
     "helper/consts",
     "helper/errutil",
+    "helper/hclutil",
     "helper/jsonutil",
     "helper/locksutil",
     "helper/logging",
     "helper/mlock",
     "helper/parseutil",
+    "helper/pathmanager",
     "helper/pluginutil",
     "helper/policyutil",
     "helper/salt",
@@ -181,8 +207,8 @@
     "version",
   ]
   pruneopts = ""
-  revision = "5dd7f25f5c4b541f2da62d70075b6f82771a650d"
-  version = "v0.10.0"
+  revision = "e21712a687889de1125e0a12a980420b1a4f72d3"
+  version = "v0.10.4"
 
 [[projects]]
   branch = "master"
@@ -194,11 +220,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:59d11e81d6fdd12a771321696bb22abdd9a94d26ac864787e98c9b419e428734"
+  digest = "1:83854f6b1d2ce047b69657e3a87ba7602f4c5505e8bdfd02ab857db8e983bde1"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = ""
-  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+  revision = "58046073cbffe2f25d425fe1331102f55cf719de"
 
 [[projects]]
   branch = "master"
@@ -210,11 +236,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:59fa50d593e5673a0dfffa1852b66fd700c05b35e368680b4b89a68fdb2c1379"
+  digest = "1:f43ed2c836208c14f45158fd01577c985688a4d11cf9fd475a939819fef3b321"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   pruneopts = ""
-  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
   digest = "1:94e9081cc450d2cdf4e6886fc2c06c07272f86477df2d74ee5931951fa3d2577"
@@ -234,32 +260,24 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4592f9136f6d4289dbdea1b5aed5f23234bf75bbabc094203aea0363a760ddec"
-  name = "github.com/sethgrid/pester"
-  packages = ["."]
-  pruneopts = ""
-  revision = "ed9870dad3170c0b25ab9b11830cc57c3a7798fb"
-
-[[projects]]
-  branch = "master"
-  digest = "1:40dd5a4f1e82c4d3dc3de550a96152f6a8937bcfcb20c7ee34685f8764e1bda5"
+  digest = "1:b970d5e8b11b4c8927a06298566eb8daf66a009702688b4142cc2a961e374e91"
   name = "golang.org/x/net"
   packages = [
     "context",
     "context/ctxhttp",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "lex/httplex",
     "trace",
   ]
   pruneopts = ""
-  revision = "61147c48b25b599e5b561d2e9c4f3e1ef489ca41"
+  revision = "f4c29de78a2a91c00474a2e689954305c350adf9"
 
 [[projects]]
   branch = "master"
-  digest = "1:217f34bc3104f3375cb368fb264fba24a300301e54a32d67a7e4b91699518e86"
+  digest = "1:a8172cf4304ef01f0c7dd634c331880247d10f9e28b041821f2321a8e4bb3b7c"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -269,15 +287,15 @@
     "jwt",
   ]
   pruneopts = ""
-  revision = "921ae394b9430ed4fb549668d7b087601bd60a81"
+  revision = "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
 
 [[projects]]
   branch = "master"
-  digest = "1:e9490adb0a1d5ac8f621a6430754822f87e565fd71d4cd1c9c4d90626f390624"
+  digest = "1:9ca540a348c8f7bc0eb140238fe1639beebe93f2b19ef326c455f4833ba708c0"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = ""
-  revision = "3b87a42e500a6dc65dae1a55d0b641295971163e"
+  revision = "0ffbfd41fbef8ffcf9b62b0b0aa3a5873ed7a4fe"
 
 [[projects]]
   digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
@@ -304,7 +322,15 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:41ba2eea537b3f64f056efb1d1f71aa2f59d1780e1d7d2957296383582e1d012"
+  digest = "1:55a681cb66f28755765fa5fa5104cbd8dc85c55c02d206f9f89566451e3fe1aa"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = ""
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ec878489340337eb7fbc52c6e067235b2a3f11e4ecc618eb213e9ba5c5bb189b"
   name = "google.golang.org/api"
   packages = [
     "admin/directory/v1",
@@ -314,10 +340,10 @@
     "oauth2/v2",
   ]
   pruneopts = ""
-  revision = "9f7560f3b05bd90f33f9d56a449e5afd4dab15b3"
+  revision = "6c5c3d4ff96110173c63a6ffea8f2ffc8bb541b4"
 
 [[projects]]
-  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
+  digest = "1:c1771ca6060335f9768dff6558108bc5ef6c58506821ad43377ee23ff059e472"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -332,19 +358,19 @@
     "urlfetch",
   ]
   pruneopts = ""
-  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
-  version = "v1.0.0"
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:d356fdec31019a0b84e3aa615784d7e2d111edb0abacd99a1e583e9ae346d9d5"
+  digest = "1:c7ecd434ece8887311c33ea3c731e2fb42f43092a43545e350b493b9dcb023b2"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = ""
-  revision = "51d0944304c3cbce4afe9e5247e21100037bff78"
+  revision = "daca94659cb50e9f37c1b834680f2e46358f10b0"
 
 [[projects]]
-  digest = "1:e5e4d08a5e43727ae54ea371823ce14b2d5b454536cfa7e6b08cc309a51d9fe5"
+  digest = "1:ca75b3775a5d4e5d1fb48f57ef0865b4aaa8b3f00e6b52be68db991c4594e0a7"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -356,11 +382,15 @@
     "credentials",
     "encoding",
     "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
     "grpclog",
     "health",
     "health/grpc_health_v1",
     "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
@@ -371,11 +401,10 @@
     "stats",
     "status",
     "tap",
-    "transport",
   ]
   pruneopts = ""
-  revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
-  version = "v1.11.3"
+  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
+  version = "v1.14.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -387,6 +387,7 @@
     "github.com/hashicorp/vault/logical",
     "github.com/hashicorp/vault/logical/framework",
     "github.com/hashicorp/vault/logical/plugin",
+    "golang.org/x/net/context",
     "golang.org/x/oauth2",
     "golang.org/x/oauth2/google",
     "google.golang.org/api/admin/directory/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,105 +2,142 @@
 
 
 [[projects]]
+  digest = "1:62750fcd190d5c1a50ed49fcbfa70ef83d7481a4d5570de677a82411091c4bf5"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
+  pruneopts = ""
   revision = "29f476ffa9c4cd4fd14336b6043090ac1ad76733"
   version = "v0.21.0"
 
 [[projects]]
+  digest = "1:8855efc2aff3afd6319da41b22a8ca1cfd1698af05a24852c01636ba65b133f0"
   name = "github.com/SermoDigital/jose"
   packages = [
     ".",
     "crypto",
     "jws",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = ""
   revision = "f6df55f235c24f236d11dbcf665249a59ac2021f"
   version = "1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:2a1e6af234d7de1ccf4504f397cf7cfa82922ee59b29252e3c34cb38d0b91989"
   name = "github.com/armon/go-radix"
   packages = ["."]
+  pruneopts = ""
   revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
 
 [[projects]]
+  digest = "1:cbe7db578d0c49383c237ab4b5d47dc7d3a12cbf5d2abdd2dd083bb5c2223cc9"
+  name = "github.com/erozario/vault-auth-google"
+  packages = ["google"]
+  pruneopts = ""
+  revision = "1b8f7734c9122666026bc2bc498c53a7efb3d344"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:bcb38c8fc9b21bb8682ce2d605a7d4aeb618abc7f827e3ac0b27c0371fdb23fb"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = ""
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:09307dfb1aa3f49a2bf869dcfa4c6c06ecd3c207221bd1c1a1141f0e51f209eb"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = ""
   revision = "553a641470496b2327abcac10b36396bd98e45c9"
 
 [[projects]]
   branch = "master"
+  digest = "1:304c322b62533a48ac052ffee80f67087fce1bc07186cd4e610a1b0e77765836"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = ""
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
   branch = "master"
+  digest = "1:f5d25fd7bdda08e39e01193ef94a1ebf7547b1b931bcdec785d08050598f306c"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = ""
   revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
 
 [[projects]]
   branch = "master"
+  digest = "1:fc9a2736d92cf885c9b3c7f202d3aaf783bb2cc4124078f0ef7667b72173b66c"
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
+  pruneopts = ""
   revision = "69ff559dc25f3b435631604f573a5fa1efdb6433"
 
 [[projects]]
   branch = "master"
+  digest = "1:b46ef59de1f724e8a2b508ea2b329eaf6cac4d71cbd44ad5e3dbd4e8fd49de9b"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = ""
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
   branch = "master"
+  digest = "1:de20979176f5f326a028fd0d3698f4ec18f6921b46c9d68a35200355c6e8e6b9"
   name = "github.com/hashicorp/go-plugin"
   packages = ["."]
+  pruneopts = ""
   revision = "e8d22c780116115ae5624720c9af0c97afe4f551"
 
 [[projects]]
   branch = "master"
+  digest = "1:ff65bf6fc4d1116f94ac305342725c21b55c16819c2606adc8f527755716937f"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
+  pruneopts = ""
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
   branch = "master"
+  digest = "1:a531cc8f8d78655eaec90f714bf81015badc2bc6682ff1eda3fa03b6568b602b"
   name = "github.com/hashicorp/go-uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "27454136f0364f2d44b1276c552d69105cf8c498"
 
 [[projects]]
   branch = "master"
+  digest = "1:94158926759c3333201f81eee5a21112f7ae9d000b4d6926455008c7ab3fb7fc"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
+  pruneopts = ""
   revision = "23480c0665776210b5fbbac6eaaee40e3e6a96b7"
 
 [[projects]]
   branch = "master"
+  digest = "1:9c776d7d9c54b7ed89f119e449983c3f24c0023e75001d6092442412ebca6b94"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = ""
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
+  digest = "1:9b7c5846d70f425d7fe279595e32a20994c6075e87be03b5c367ed07280877c5"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -111,11 +148,13 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = ""
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
+  digest = "1:820c02b39c079c8919901ea9cc75b93ae8bc0864271494f40f7eb78fd69a8cbb"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
@@ -139,55 +178,71 @@
     "logical/plugin/pb",
     "physical",
     "physical/inmem",
-    "version"
+    "version",
   ]
+  pruneopts = ""
   revision = "5dd7f25f5c4b541f2da62d70075b6f82771a650d"
   version = "v0.10.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:502c6c45a693da0396113cf025f65da5c9ad15c542328cfbc8c4663a10cc707d"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
-  revision = "2658be15c5f05e76244154714161f17e3e77de2e"
+  pruneopts = ""
+  revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
   branch = "master"
+  digest = "1:59d11e81d6fdd12a771321696bb22abdd9a94d26ac864787e98c9b419e428734"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = ""
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
   branch = "master"
+  digest = "1:51c98e2c9a8d0a724a69f46421876af14e12132cb02f1d0e144785d752247162"
   name = "github.com/mitchellh/go-testing-interface"
   packages = ["."]
+  pruneopts = ""
   revision = "a61a99592b77c9ba629d254a693acffaeb4b7e28"
 
 [[projects]]
   branch = "master"
+  digest = "1:59fa50d593e5673a0dfffa1852b66fd700c05b35e368680b4b89a68fdb2c1379"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
+  digest = "1:94e9081cc450d2cdf4e6886fc2c06c07272f86477df2d74ee5931951fa3d2577"
   name = "github.com/oklog/run"
   packages = ["."]
+  pruneopts = ""
   revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:29df111893b87bd947307aab294c042e900c2f29c53ad3896127955b4283728a"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
+  pruneopts = ""
   revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
   version = "v0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:4592f9136f6d4289dbdea1b5aed5f23234bf75bbabc094203aea0363a760ddec"
   name = "github.com/sethgrid/pester"
   packages = ["."]
+  pruneopts = ""
   revision = "ed9870dad3170c0b25ab9b11830cc57c3a7798fb"
 
 [[projects]]
   branch = "master"
+  digest = "1:40dd5a4f1e82c4d3dc3de550a96152f6a8937bcfcb20c7ee34685f8764e1bda5"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -197,29 +252,35 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace"
+    "trace",
   ]
+  pruneopts = ""
   revision = "61147c48b25b599e5b561d2e9c4f3e1ef489ca41"
 
 [[projects]]
   branch = "master"
+  digest = "1:217f34bc3104f3375cb368fb264fba24a300301e54a32d67a7e4b91699518e86"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = ""
   revision = "921ae394b9430ed4fb549668d7b087601bd60a81"
 
 [[projects]]
   branch = "master"
+  digest = "1:e9490adb0a1d5ac8f621a6430754822f87e565fd71d4cd1c9c4d90626f390624"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "3b87a42e500a6dc65dae1a55d0b641295971163e"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -235,24 +296,28 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:41ba2eea537b3f64f056efb1d1f71aa2f59d1780e1d7d2957296383582e1d012"
   name = "google.golang.org/api"
   packages = [
     "admin/directory/v1",
     "gensupport",
     "googleapi",
     "googleapi/internal/uritemplates",
-    "oauth2/v2"
+    "oauth2/v2",
   ]
+  pruneopts = ""
   revision = "9f7560f3b05bd90f33f9d56a449e5afd4dab15b3"
 
 [[projects]]
+  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -264,18 +329,22 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = ""
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d356fdec31019a0b84e3aa615784d7e2d111edb0abacd99a1e583e9ae346d9d5"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = ""
   revision = "51d0944304c3cbce4afe9e5247e21100037bff78"
 
 [[projects]]
+  digest = "1:e5e4d08a5e43727ae54ea371823ce14b2d5b454536cfa7e6b08cc309a51d9fe5"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -302,14 +371,26 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = ""
   revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
   version = "v1.11.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d3e9659f60acf07ccbf1d59ed10ec2988b92820dc693cb52f11d394a0a5a999c"
+  input-imports = [
+    "github.com/erozario/vault-auth-google/google",
+    "github.com/hashicorp/vault/helper/pluginutil",
+    "github.com/hashicorp/vault/helper/policyutil",
+    "github.com/hashicorp/vault/logical",
+    "github.com/hashicorp/vault/logical/framework",
+    "github.com/hashicorp/vault/logical/plugin",
+    "golang.org/x/oauth2",
+    "golang.org/x/oauth2/google",
+    "google.golang.org/api/admin/directory/v1",
+    "google.golang.org/api/oauth2/v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Vault Auth Google
 
-A Vault plugin for authenticating and receiving policies via Google Accounts
-(Gmail and G Suite).
+A [Hashicorp Vault](https://github.com/hashicorp/vault) plugin that enables
+authentication and policy bounding via Google Accounts and Google Groups (G
+Suite only).
 
 
 ## Table of Contents
@@ -12,13 +13,11 @@ A Vault plugin for authenticating and receiving policies via Google Accounts
     - [From source](#from-source)
  - [Google API requirements](#google-api-requirements)
  - [Installation](#installation)
- - [Configuration](#configuration)
- - [Usage](#usage)
-    - [Creating roles](#creating-roles)
-       - [Gmail](#gmail)
-       - [G Suite](#g-suite)
-    - [Google's OAuth URL](#googles-oauth-url)
- - [Local environment setup](#local-environment-setup)
+ - [Configuration & Usage](#configuration--usage)
+    - [Parameters](#binary)
+    - [Local flow vs. Web-based flow](#local-flow-vs-web-based-flow)
+    - [How to...](#how-to)
+ - [Contributing](#contributing)
  - [License](#license)
 
 
@@ -31,11 +30,10 @@ A Vault plugin for authenticating and receiving policies via Google Accounts
 
 ## Getting
 
-After downloading the binary, move it into the [plugin
+You can get the plugin binary via the release page or building yourself. After
+getting the binary, move it into the [plugin
 directory](https://www.vaultproject.io/guides/operations/plugin-backends.html)
-configured at the Vault's configuration file. You can get the plugin binary via
-the release page or building yourself.
-
+set at the Vault's configuration file.
 
 ### Binary
 
@@ -50,26 +48,24 @@ Clone this repository and build via `make`:
 make all
 ```
 
-The make recipe requires [dep](https://github.com/golang/dep) in order to get the project's dependencies.
+The make recipe requires [dep](https://github.com/golang/dep) in order to get
+the project's dependencies.
 
-Alternatively, you can get the dependencies via `go get <dependency>`.
+Alternatively, you can get the dependencies via `go get`.
 
 
 ## Google API requirements
 
-In order to authenticate with your Google or G Suite account,
-`vault-auth-google` requires an OAuth client ID and secret. You can generate
-the client ID and secret at the Google Cloud Console, on the [credential
-section](https://console.cloud.google.com/apis/credentials).
+`vault-auth-google` requires an OAuth2 credential in order to authenticate
+Google Accounts into Vault. For G Suite users with group bounding, the plugin
+also requires a domain-wide service account for user impersonation.
 
-For a local oauth flow, set the credential type as *Other*. For an online
-authentication flow (that requires redirection), set as *Web application*.
+Though it requires the `Admin SDK` API enabled, `vault-auth-google` only make
+use of the [admin.directory.group.readonly](https://developers.google.com/admin-sdk/directory/v1/guides/authorizing)
+function.
 
-For bounding policies with G Suite email groups, the plugin requires access to
-the [Admin SDK](https://developers.google.com/admin-sdk/directory/v1/guides/authorizing).
-
-On more information about who to create OAuth credentials and Service Accounts
-for domain-wide delegation, check the docs:
+For more information on how to create OAuth2 credentials and service account
+keys, check the docs:
 
 * [Creating an OAuth Credential on GCP](docs/oauth.md)
 * [Creating a Service Account on GCP for G Suite user impersonation](docs/service-account.md)
@@ -77,16 +73,27 @@ for domain-wide delegation, check the docs:
 
 ## Installation
 
-* Calculate and register the SHA256 sum of the plugin in Vault's plugin catalog:
+Third-party auth methods, such as this, cannot be enabled the same way as
+native [auth methods](https://www.vaultproject.io/docs/auth/index.html). To
+install it, add the plugin into the [plugin
+catalog](https://www.vaultproject.io/docs/internals/plugins.html#plugin-catalog).
+
+* After [getting the plugin](#getting) binary, calculate the SHA256 of it and stores it
+  inside an environment variable for easy reference.
 
 ```sh
 SHASUM=$(shasum -a 256 "/path/to/vault-auth-google" | cut -d " " -f1)
+```
+
+* Register the binary and its SHASUM in Vault's plugin catalog
+
+```sh
 vault write sys/plugins/catalog/vault-auth-google \
   sha_256="$SHASUM" \
   command="vault-auth-google"
 ```
 
-* Mount the auth method:
+* Finally, mount the `vault-auth-google` as an auth method.
 
 ```sh
 vault auth enable \
@@ -95,115 +102,81 @@ vault auth enable \
 ```
 
 
-## Configuration
+## Configuration & Usage
 
-The plugin is set to receive four parameters, two of which are required:
+The configuration of this auth method depends on the kind of the Google Account
+used and the OAuth2 flow. Both Gmail and G Suite accounts requires OAuth2
+credentials for user authentication, but the [kind of flow can
+differ](https://developers.google.com/identity/protocols/OAuth2).
 
- - _(string)_ `client_id` __*__: The Google OAuth client id.
- - _(string)_ `client_secret` __*__: The Google OAuth client secret.
- - _(boolean)_ `fetch_groups`: Should the plugin bound policies to groups? `true` if yes, `false` otherwise.
- - _(string)_ `redirect_url`: The URL that google will redirect after the OAuth
-     flow. This URL should also be added at the credentials authorized URIs..
+The plugin can be configured via parameters. Each parameter have a different
+effect on the plugin and serves different purposes.
+
+
+### Parameters
+
+`vault-auth-google` can be configured via five parameters, two of which are
+required:
+
+ - _(string)_ `client_id` __*__: The Google OAuth2 Client ID.
+ - _(string)_ `client_secret` __*__: The Google OAuth2 Client secret.
+ - _(boolean)_ `fetch_groups`: Should the plugin bound policies to groups? **true** if yes, **false** otherwise.
+ - _(string)_ `redirect_url`: The URL that Google will redirect after the
+     OAuth2 flow. This URL should also be added at the credentials authorized URIs.
+ - _(string_ `delegation_user`: The Google user that delegates the API permission.
+ - _(string)_ `service_acc_key`: The content of the Service Account private key.
 
 __* Required parameters__
 
 
-Configuring the auth method:
+### Local flow vs. Web-based flow
 
-```sh
-vault write auth/google/config \
-    client_id=<GOOGLE_CLIENT_ID> \
-    client_secret=<GOOGLE_CLIENT_SECRET> \
-    redirect_url="https://domain.com/redirect" \
-    fetch_groups=true
-```
+The flow can be made on the [local
+machine](https://developers.google.com/identity/protocols/OAuth2InstalledApp)
+or via [web
+services](https://developers.google.com/identity/protocols/OAuth2WebServer).
 
+Local authentication flows generates a temporary, one-time usage Google token.
+The Google OAuth token have to be written in Vault, so it can then generate
+it's own access token with policy builtin on.
 
-## Usage
+The difference between a local flow and a web-based flow on this plugin mostly
+relies on the `redirect_url` parameter. This parameter is optional and unset by
+default. When unset, the plugin assumes a local flow. Since Vault cannot handle
+a GET callback from Google, the token has to be feeded manually. E.g.:
 
-### Creating roles
-
- - _(string)_ `bound_emails`: The list of emails bound to the role.
- - _(string)_ `bound_domain`: The domain name bound to the role. When
-     defining a bounded domain, the plugin expects that the emails are part of
-     the domain.
- - _(string)_ `bound_groups`: The google group email bound the to role. When
-     bounding a group to a role, every user within the group will be assigned to
-     the policy.
- - _(string)_ `policies`: The policy name associated with the role.
-
-#### Gmail
-
-Creating a role to a Gmail account:
-```sh
-vault write auth/google/role/default \
-    bound_emails=user@gmail.com \
-    policies=default
-```
-
-#### G Suite
-
-Creating a role to a G Suite account, bounding a groups:
-```sh
-vault write auth/google/role/default \
-    bound_domain=<DOMAIN> \
-    bound_groups=sec@<DOMAIN>,infra@<DOMAIN> \
-    policies=default
-```
-
-
-### Google's OAuth URL
-
-* Login using Google credentials
+* Gets a Google OAuth flow URL from Vault and opens it with Firefox.
 
 ```sh
 firefox $(vault read -field=url auth/google/code_url)
-vault write auth/google/login code=$GOOGLE_CODE role=default
 ```
 
-
-## Local environment setup
-
-* Clone this repo
+* Writes the Google code on Vault for a token generation.
 
 ```sh
-git clone git@github.com:erozario/vault-auth-google.git
+vault write auth/google/login code=<GOOGLE-OAUTH2-CODE> role=default
 ```
 
-* Create a temporary directory to compile the plugin into and to use as the plugin directory for Vault:
+Alternatively, when `redirect_url` is setted, the plugin assumes a web-based
+flow and uses the given URL as  the Redirect URI used by the Google OAuth2
+credential. It is important to notice that this URL has to be a web application
+ready to handle GET requests, since Google will make the request on it, passing
+the authorization code as a GET parameter.
 
-```sh
-mkdir -p /tmp/vault-plugins
-```
 
-* Compile the plugin into the temporary directory:
+### How to...
 
-```sh
-go build -o /tmp/vault-plugins/vault-auth-google
-```
+* [Configure `vault-auth-google` and use it for Gmail accounts](docs/gmail.md)
+* [Configure `vault-auth-google` and use it for G Suite accounts (with group bounding)](docs/gsuite.md)
 
-* Create a configuration file to point Vault at this plugin directory:
 
-```sh
-tee /tmp/vault.hcl <<EOF
-plugin_directory = "/tmp/vault-plugins"
-EOF
-```
+## Contributing
 
-* Start a Vault server in development mode with the configuration:
-
-```sh
-vault server -dev -dev-root-token-id="root" -config=/tmp/vault.hcl &
-```
-
-* Leave this running and open a new tab or terminal window. Authenticate to Vault:
-
-```sh
-export VAULT_ADDR='http://127.0.0.1:8200'
-vault login root
-```
+If you wish to contribute to this project, either by fixing a bug or suggesting
+new functionalities, check the documentation on how to setup a [local
+environment for development](docs/local-dev.md).
 
 
 ## License
 
-This code is licensed under the Mozilla Public License.
+This project is licensed under the [Mozilla Public License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ authentication flow (that requires redirection), set as *Web application*.
 For bounding policies with G Suite email groups, the plugin requires access to
 the [Admin SDK](https://developers.google.com/admin-sdk/directory/v1/guides/authorizing).
 
+On more information about who to create OAuth credentials and Service Accounts
+for domain-wide delegation, check the docs:
+
+* [Creating an OAuth Credential on GCP](docs/oauth.md)
+* [Creating a Service Account on GCP for G Suite user impersonation](docs/service-account.md)
+
 
 ## Installation
 

--- a/docs/gmail.md
+++ b/docs/gmail.md
@@ -41,10 +41,11 @@ vault write auth/google/config \
 After configuring the auth method, a role, bounding a given email to a policy,
 is required. The following parameters are expected to create a role:
 
- - _(string)_ `bound_emails`: The list of emails bound to the policy.
- - _(string)_ `policies`: The policy name associated with the role.
+ - _(string)_ `bound_emails`: A list of email addresses bounding users to a
+     given policy.
+ - _(string)_ `policies`: The list of policies associated with the role.
 
-### Creating a role to a Gmail account:
+### Creating a role bounding a policy to a Gmail account
 
 The following snippet creates a role named `default`, bounding the email
 `user@gmail.com`  to the policy `my-policy`. For multiple association,
@@ -53,5 +54,5 @@ delimiter the email addresses by comma.
 ```sh
 vault write auth/google/role/default \
     bound_emails="user@gmail.com" \
-    policies=my-policy
+    policies="my-policy"
 ```

--- a/docs/gmail.md
+++ b/docs/gmail.md
@@ -1,0 +1,57 @@
+# How to configure `vault-auth-google` and use it for Gmail accounts
+
+Setting `vault-auth-google` up for Gmail accounts is quite simple and
+straightforward, since the only kind of policy bound available is the email
+address bounding.
+
+
+## Configuration
+
+The configuration expects the following two required parameters:
+
+ - _(string)_ `client_id`: The Google OAuth Client ID.
+ - _(string)_ `client_secret`: The Google OAuth Client secret.
+
+Instructions on how to create an OAuth2 credential is available [here](oauth.md).
+
+### Configuring the auth method with local OAuth2 flow
+
+```sh
+vault write auth/google/config \
+    client_id=<GOOGLE_CLIENT_ID> \
+    client_secret=<GOOGLE_CLIENT_SECRET>
+```
+
+
+### Configuring the auth method with web-based OAuth2 flow
+
+To configure a web-based flow, set the `redirect_url` parameter with the
+desired callback URL.
+
+```sh
+vault write auth/google/config \
+    client_id="<GOOGLE_CLIENT_ID>" \
+    client_secret="<GOOGLE_CLIENT_SECRET>" \
+    redirect_url="https://domain.com/redirect"
+```
+
+
+## Usage
+
+After configuring the auth method, a role, bounding a given email to a policy,
+is required. The following parameters are expected to create a role:
+
+ - _(string)_ `bound_emails`: The list of emails bound to the policy.
+ - _(string)_ `policies`: The policy name associated with the role.
+
+### Creating a role to a Gmail account:
+
+The following snippet creates a role named `default`, bounding the email
+`user@gmail.com`  to the policy `my-policy`. For multiple association,
+delimiter the email addresses by comma.
+
+```sh
+vault write auth/google/role/default \
+    bound_emails="user@gmail.com" \
+    policies=my-policy
+```

--- a/docs/gsuite.md
+++ b/docs/gsuite.md
@@ -1,0 +1,84 @@
+# How to configure `vault-auth-google` and use it for G Suite accounts
+
+Setting `vault-auth-google` up on G Suite accounts requires a larger set of
+parameters and configurations, but extends the capabilities of policy bounding,
+since you can bound policies not only to email addresses, but on Google Groups
+and its members. This allow a more granular set of permissions: each group is
+bound to a specific policy; to grant or revoke permissions on a given user, the
+G Suite Admin only have to add ou remove that user to the group.
+
+
+## Configuration
+
+### Configuring the auth method with group bounding and web-based OAuth2 flow
+
+To enable `vault-auth-google` to bound policies to Google groups and its
+members, you must create a domain-wide Service Account on GCP for user
+impersonation on G Suite.
+
+Instructions on how to create an OAuth2 credential is available
+[here](oauth.md). On how to create a Service Account key, check
+[here](service-account.md).
+
+The following parameters are required:
+
+ - _(string)_ `client_id`: The Google OAuth Client ID.
+ - _(string)_ `client_secret`: The Google OAuth Client secret.
+ - _(boolean)_ `fetch_groups`: Should the plugin bound policies to groups? **true** if yes, **false** otherwise.
+ - _(string_ `delegation_user`: The Google user that delegates the API permission.
+ - _(string)_ `service_acc_key`: The content of the Service Account private key.
+
+After creating the OAuth credential and the Service Account key, follow the steps:
+
+- Read the Service Account key content and stores it inside an environment
+  variable for easy reference.
+
+```sh
+SERVICE_ACCOUNT_KEY=$(cat /path/to/the/key.json)
+```
+
+- Write the parameters onto the plugin's configuration.
+
+```sh
+vault write auth/google/config \
+    client_id="<GOOGLE_CLIENT_ID>" \
+    client_secret="<GOOGLE_CLIENT_SECRET>" \
+    redirect_url="https://domain.com/redirect" \
+    fetch_groups=true \
+    delegation_user="user@domain.com" \
+    service_acc_key=$SERVICE_ACCOUNT_KEY
+```
+
+Bare in mind that the delegation user must be the same one referenced at the
+moment the Service Account were created. The `delegation_user` parameter tells
+`vault-auth-google` which user must be impersonated in order to Vault be able
+to list your organization's groups. The `service_acc_key` will have the Service
+Account private key's content, authorizing the impersonation.
+
+
+## Usage
+
+After configuring the auth method, a role, bounding a given email or group to a
+policy, is required. The following parameters are expected to create a role:
+
+ - _(string)_ `bound_domain`: A domain name bounding a G Suite organization to
+     a given policy. When setting a bounded domain, the plugin expects that
+     all email addresses (users or groups) are part of the domain.
+ - _(string)_ `bound_emails`: A list of email addresses bounding users to a
+     given policy.
+ - _(string)_ `bound_groups`: A list of Google groups bounding its members to a
+     given policy.
+ - _(string)_ `policies`: The list of policies associated with the role.
+
+### Creating a role bounding a policy to a G Suite group
+
+The following snippet creates a role named `default`, bounding the G Suite
+groups `infra@domain.com` and `dev@domain.com` to the policies
+`read-only-repos` and `read-only-machines`.
+
+```sh
+vault write auth/google/role/default \
+    bound_domain="domain.com" \
+    bound_groups="infra@domain.com, dev@domain.com" \
+    policies="read-only-repos, read-only-machines"
+```

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,52 @@
+# Setting up a local development environment
+
+You'll first need Go properly installed on your machine. You can follow Go's
+documentation on [how to get started](https://golang.org/doc).
+
+1. Clone this repository inside Go's workspace. The workspace path is generally
+   mapped into the `GOPATH` environment variable.
+
+```sh
+git clone git@github.com:erozario/vault-auth-google.git $GOPATH/src
+```
+
+
+1. Create a temporary directory to compile the plugin into and to use as the
+   plugin directory for Vault.
+
+```sh
+mkdir -p /tmp/vault-plugins
+```
+
+
+1. Compile the plugin into the temporary directory.
+
+```sh
+cd $GOPATH/src/vault-auth-google && go build -o /tmp/vault-plugins/vault-auth-google
+```
+
+
+1. Create a configuration file that sets the temporary directory as the Vault's
+   plugin directory.
+
+```sh
+tee /tmp/vault.hcl <<EOF
+plugin_directory = "/tmp/vault-plugins"
+EOF
+```
+
+
+1. Start the Vault server in development mode, referencing the configuration
+   file.
+
+```sh
+vault server -dev -dev-root-token-id="root" -config=/tmp/vault.hcl &
+```
+
+
+1. Leave this running and open a new tab or terminal window. Authenticate to Vault:
+
+```sh
+export VAULT_ADDR='http://127.0.0.1:8200'
+vault login root
+```

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -19,5 +19,5 @@ credential is essencial in order to Vault verifies who you are.
 
 ## References
 
-* [Setting up OAuth 2.0](https://support.google.com/cloud/answer/6158849?hl=en)
-* [Enable and disable APIs](https://support.google.com/cloud/answer/6158841?hl=en&ref_topic=6262490)
+- [Setting up OAuth 2.0](https://support.google.com/cloud/answer/6158849?hl=en)
+- [Enable and disable APIs](https://support.google.com/cloud/answer/6158841?hl=en&ref_topic=6262490)

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,23 @@
+# Creating an OAuth Credential on GCP
+
+## Why?
+
+The OAuth credential provides Vault a way to authenticate through your G Suite
+account and get basic information about you, like your email address. This is
+credential is essencial in order to Vault verifies who you are.
+
+## How?
+
+1. Open the [Google Cloud Plataform](https://console.cloud.google.com) console;
+1. On the left side panel, access the **APIs & Services** section;
+1. At the section, on the left side panel, click on **Credentials**;
+1. Configure the **Oauth consent screen**, configuring a *product name*;
+1. On the **Library**, enable the *Admin SDK API*;
+1. On **Credentials**, create a new  *OAuth client ID* credential;
+1. Set the **Application type** as *Web application* and fill the *Name* field;
+1. Save the **OAuth Client ID** and **Client Secret**.
+
+## References
+
+* [Setting up OAuth 2.0](https://support.google.com/cloud/answer/6158849?hl=en)
+* [Enable and disable APIs](https://support.google.com/cloud/answer/6158841?hl=en&ref_topic=6262490)

--- a/docs/service-account.md
+++ b/docs/service-account.md
@@ -1,0 +1,54 @@
+# Creating a Service Account on GCP for G Suite user impersonation
+
+## Why?
+
+`vault-auth-google` requires Google Groups read-only capabilities in order to
+list all existing groups within the organizational unit and their members.
+Though this permission could be granted through OAuth, not every member inside
+G Suite has the correct permissions to list groups information. The service
+account is able to provide the applicaton a way to impersonate a given user and
+use their permissions.
+
+## How?
+
+### Administrative roles on G Suite
+
+1. Open the [G Suite Admin console](https://admin.google.com);
+1. Access the **User** section, find the user and click on it;
+1. Expand the **Admin roles and privileges** section;
+1. Assign the **Groups Admin** role to the user.
+
+### Service account
+
+1. Access the [Google Cloud Plataform](https://console.cloud.google.com);
+1. On the left side panel, access the **IAM & admin** section;
+1. At the section, add the G Suite group admin as a *Service Account Actor*;
+1. On the left side panel, access the **Service accounts** section;
+1. Click on **CREATE SERVICE ACCOUNT** at the top of the page;
+1. Fill the *Service account name* and *Enable G Suite Domain-wide Delegation*;
+1. On the left side panel, access the **APIs & Services** section;
+1. On **Credentials**, create a new  *Service account key*;
+1. At the *Service account key* creation page, select the service account on
+   the dropdown menu as set the *Key type* as JSON.
+1. On the **Library**, enable the *Admin SDK API*;
+1. Save the Service Account credendential file and the service account client
+   ID;
+
+### API scope
+
+1. Back to the [G Suite Admin console](https://admin.google.com), access the
+   **Security** section;
+1. At the section, expand the **Advanced settings** and click on *Manage API
+   client access*;
+1. On the **Client Name** text box, insert the *Client ID* of the newly created
+   service account;
+1. On the **One or More API Scopes**, insert the *Google Groups Read-Only API
+   scope*.
+1. Authorize the API client access clicking on **Authorize**.
+
+
+## References
+
+* **Google Groups Read-Only API scope**: `https://www.googleapis.com/auth/admin.directory.group.readonly`
+* [About admnistrator role](https://support.google.com/a/answer/33325?hl=en)
+* [Assign administrator to a user](https://support.google.com/a/answer/172176?hl=en)

--- a/docs/service-account.md
+++ b/docs/service-account.md
@@ -49,9 +49,9 @@ use their permissions.
 
 ## References
 
-* **Google Groups Read-Only API scope**: `https://www.googleapis.com/auth/admin.directory.group.readonly`
-* [About admnistrator role](https://support.google.com/a/answer/33325?hl=en)
-* [Assign administrator to a user](https://support.google.com/a/answer/172176?hl=en)
-* [Understanding Service Accounts](https://cloud.google.com/iam/docs/understanding-service-accounts)
-* [Perform G Suite Domain-Wide Delegation of Authority](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
-* [OAuth 2.0 Scopes for Google APIs](https://developers.google.com/identity/protocols/googlescopes)
+- **Google Groups Read-Only API scope**: `https://www.googleapis.com/auth/admin.directory.group.readonly`
+- [About admnistrator role](https://support.google.com/a/answer/33325?hl=en)
+- [Assign administrator to a user](https://support.google.com/a/answer/172176?hl=en)
+- [Understanding Service Accounts](https://cloud.google.com/iam/docs/understanding-service-accounts)
+- [Perform G Suite Domain-Wide Delegation of Authority](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
+- [OAuth 2.0 Scopes for Google APIs](https://developers.google.com/identity/protocols/googlescopes)

--- a/docs/service-account.md
+++ b/docs/service-account.md
@@ -52,3 +52,6 @@ use their permissions.
 * **Google Groups Read-Only API scope**: `https://www.googleapis.com/auth/admin.directory.group.readonly`
 * [About admnistrator role](https://support.google.com/a/answer/33325?hl=en)
 * [Assign administrator to a user](https://support.google.com/a/answer/172176?hl=en)
+* [Understanding Service Accounts](https://cloud.google.com/iam/docs/understanding-service-accounts)
+* [Perform G Suite Domain-Wide Delegation of Authority](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
+* [OAuth 2.0 Scopes for Google APIs](https://developers.google.com/identity/protocols/googlescopes)

--- a/google/backend.go
+++ b/google/backend.go
@@ -45,11 +45,11 @@ func newBackend() *backend {
 				Fields: map[string]*framework.FieldSchema{
 					clientIDConfigPropertyName: &framework.FieldSchema{
 						Type:        framework.TypeString,
-						Description: "Google application ID",
+						Description: "Google OAuth client id",
 					},
 					clientSecretConfigPropertyName: &framework.FieldSchema{
 						Type:        framework.TypeString,
-						Description: "Google application secret",
+						Description: "Google OAuth client secret",
 					},
 					clientOAuthRedirectUrlPropertyName: &framework.FieldSchema{
 						Type:        framework.TypeString,
@@ -58,6 +58,14 @@ func newBackend() *backend {
 					clientFetchGroupsConfigPropertyName: &framework.FieldSchema{
 						Type:        framework.TypeBool,
 						Description: "Google fetch groups",
+					},
+					clientServiceAccountKeyConfigPropertyName: &framework.FieldSchema{
+						Type:        framework.TypeString,
+						Description: "Google service account key content",
+					},
+					clientDelegationUserConfigPropertyName: &framework.FieldSchema{
+						Type:        framework.TypeString,
+						Description: "Google delegation email address",
 					},
 				},
 

--- a/google/path_config.go
+++ b/google/path_config.go
@@ -113,9 +113,5 @@ func (c *config) oauth2Config() *oauth2.Config {
 			"https://www.googleapis.com/auth/userinfo.email",
 		},
 	}
-
-	if c.FetchGroups {
-		config.Scopes = append(config.Scopes, "https://www.googleapis.com/auth/admin.directory.group.readonly")
-	}
 	return config
 }

--- a/google/path_config.go
+++ b/google/path_config.go
@@ -13,27 +13,33 @@ import (
 )
 
 const (
-	configPath                          = "config"
-	clientIDConfigPropertyName          = "client_id"
-	clientSecretConfigPropertyName      = "client_secret"
-	clientOAuthRedirectUrlPropertyName  = "redirect_url"
-	clientFetchGroupsConfigPropertyName = "fetch_groups"
-	configEntry                         = "config"
+	configPath                                = "config"
+	clientIDConfigPropertyName                = "client_id"
+	clientSecretConfigPropertyName            = "client_secret"
+	clientOAuthRedirectUrlPropertyName        = "redirect_url"
+	clientFetchGroupsConfigPropertyName       = "fetch_groups"
+	clientServiceAccountKeyConfigPropertyName = "service_acc_key"
+	clientDelegationUserConfigPropertyName    = "delegation_user"
+	configEntry                               = "config"
 )
 
 func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	var (
-		clientID     = data.Get(clientIDConfigPropertyName).(string)
-		clientSecret = data.Get(clientSecretConfigPropertyName).(string)
-		redirectUrl  = data.Get(clientOAuthRedirectUrlPropertyName).(string)
-		fetchGroups  = data.Get(clientFetchGroupsConfigPropertyName).(bool)
+		clientID       = data.Get(clientIDConfigPropertyName).(string)
+		clientSecret   = data.Get(clientSecretConfigPropertyName).(string)
+		redirectUrl    = data.Get(clientOAuthRedirectUrlPropertyName).(string)
+		fetchGroups    = data.Get(clientFetchGroupsConfigPropertyName).(bool)
+		serviceAccount = data.Get(clientServiceAccountKeyConfigPropertyName).(string)
+		delegationUser = data.Get(clientDelegationUserConfigPropertyName).(string)
 	)
 
 	entry, err := logical.StorageEntryJSON(configEntry, config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		RedirectUrl:  redirectUrl,
-		FetchGroups:  fetchGroups,
+		ClientID:       clientID,
+		ClientSecret:   clientSecret,
+		RedirectUrl:    redirectUrl,
+		FetchGroups:    fetchGroups,
+		ServiceAccount: serviceAccount,
+		DelegationUser: delegationUser,
 	})
 	if err != nil {
 		return nil, err
@@ -52,10 +58,12 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, data
 	}
 
 	configMap := map[string]interface{}{
-		clientIDConfigPropertyName:          config.ClientID,
-		clientSecretConfigPropertyName:      config.ClientSecret,
-		clientOAuthRedirectUrlPropertyName:  config.RedirectUrl,
-		clientFetchGroupsConfigPropertyName: config.FetchGroups,
+		clientIDConfigPropertyName:                config.ClientID,
+		clientSecretConfigPropertyName:            config.ClientSecret,
+		clientOAuthRedirectUrlPropertyName:        config.RedirectUrl,
+		clientFetchGroupsConfigPropertyName:       config.FetchGroups,
+		clientServiceAccountKeyConfigPropertyName: config.ServiceAccount,
+		clientDelegationUserConfigPropertyName:    config.DelegationUser,
 	}
 
 	return &logical.Response{
@@ -82,10 +90,12 @@ func (b *backend) config(ctx context.Context, s logical.Storage) (*config, error
 }
 
 type config struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	RedirectUrl  string `json:"redirect_url"`
-	FetchGroups  bool   `json:"fetch_groups"`
+	ClientID       string `json:"client_id"`
+	ClientSecret   string `json:"client_secret"`
+	RedirectUrl    string `json:"redirect_url"`
+	FetchGroups    bool   `json:"fetch_groups"`
+	ServiceAccount string `json:"service_acc_key"`
+	DelegationUser string `json:"delegation_user"`
 }
 
 func (c *config) oauth2Config() *oauth2.Config {


### PR DESCRIPTION
- **What**: This addition includes two new optional parameters, i.e.
        `service_acc_key` and `delegation_user`. It also includes more
         documentation on topics such as OAuth2 credentials and how to
         configure the plugin on Gmail and G Suite accounts.

- **Why** : These new parameters will provide the plugin a way to use a
        G Suite, domain-wide service account to impersonate an user.
        The impersonation of an user with G Suite admin capabilities
        fixes an issue where non-admin profiles could not get through
        the OAuth flow.